### PR TITLE
Add Block List for Proxy

### DIFF
--- a/XMAT.Tests/BlockListModelTests.cs
+++ b/XMAT.Tests/BlockListModelTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// SPDX-License-Identifier: MIT
+
+using XMAT.WebServiceCapture.Models;
+
+namespace XMAT.Tests
+{
+    public class BlockListModelTests
+    {
+        [Fact]
+        public void Add_TrimsAndDeduplicates()
+        {
+            var list = new BlockListModel();
+            Assert.True(list.Add("  example.com  "));
+            Assert.False(list.Add("example.com"));
+            Assert.False(list.Add("EXAMPLE.COM"));
+            Assert.Single(list.BlockedUrls);
+            Assert.Equal("example.com", list.BlockedUrls[0]);
+        }
+
+        [Fact]
+        public void Add_RejectsEmptyOrWhitespace()
+        {
+            var list = new BlockListModel();
+            Assert.False(list.Add(null));
+            Assert.False(list.Add(""));
+            Assert.False(list.Add("   "));
+            Assert.Empty(list.BlockedUrls);
+        }
+
+        [Fact]
+        public void IsBlocked_ExactHostMatchIsCaseInsensitive()
+        {
+            var list = new BlockListModel();
+            list.Add("example.com");
+            Assert.True(list.IsBlocked("example.com"));
+            Assert.True(list.IsBlocked("EXAMPLE.COM"));
+            Assert.False(list.IsBlocked("sub.example.com"));
+            Assert.False(list.IsBlocked("other.com"));
+        }
+
+        [Fact]
+        public void IsBlocked_WildcardMatchesSubdomains()
+        {
+            var list = new BlockListModel();
+            list.Add("*.example.com");
+            Assert.True(list.IsBlocked("api.example.com"));
+            Assert.True(list.IsBlocked("a.b.example.com"));
+            Assert.False(list.IsBlocked("example.com"));
+            Assert.False(list.IsBlocked("notexample.com"));
+        }
+
+        [Fact]
+        public void IsBlocked_WildcardMatchesIpPrefix()
+        {
+            var list = new BlockListModel();
+            list.Add("192.168.1.*");
+            Assert.True(list.IsBlocked("192.168.1.5"));
+            Assert.True(list.IsBlocked("192.168.1.255"));
+            Assert.False(list.IsBlocked("192.168.2.5"));
+        }
+
+        [Fact]
+        public void IsBlocked_MatchesAgainstHostAndPath()
+        {
+            var list = new BlockListModel();
+            list.Add("example.com/blocked/*");
+            Assert.True(list.IsBlocked("example.com", "/blocked/page"));
+            Assert.True(list.IsBlocked("example.com", "blocked/page"));
+            Assert.False(list.IsBlocked("example.com", "/allowed"));
+            Assert.False(list.IsBlocked("example.com"));
+        }
+
+        [Fact]
+        public void IsBlocked_EmptyHostReturnsFalse()
+        {
+            var list = new BlockListModel();
+            list.Add("*");
+            Assert.False(list.IsBlocked(null));
+            Assert.False(list.IsBlocked(string.Empty));
+        }
+
+        [Fact]
+        public void IsBlocked_EmptyBlockListReturnsFalse()
+        {
+            var list = new BlockListModel();
+            Assert.False(list.IsBlocked("example.com"));
+        }
+
+        [Fact]
+        public void Remove_RemovesPatternCaseInsensitively()
+        {
+            var list = new BlockListModel();
+            list.Add("example.com");
+            list.Remove("EXAMPLE.COM");
+            Assert.Empty(list.BlockedUrls);
+            Assert.False(list.IsBlocked("example.com"));
+        }
+
+        [Fact]
+        public void Clear_RemovesAllPatterns()
+        {
+            var list = new BlockListModel();
+            list.Add("a.com");
+            list.Add("b.com");
+            list.Clear();
+            Assert.Empty(list.BlockedUrls);
+            Assert.False(list.IsBlocked("a.com"));
+        }
+
+        [Fact]
+        public void IsBlocked_SpecialRegexCharsInPatternAreEscaped()
+        {
+            var list = new BlockListModel();
+            list.Add("example.com");
+            // '.' must be a literal, not a regex any-char.
+            Assert.False(list.IsBlocked("exampleXcom"));
+        }
+    }
+}

--- a/XMAT/Engines/WebServiceProxy/Logic/WebServiceDeviceCaptureController.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/WebServiceDeviceCaptureController.cs
@@ -81,6 +81,7 @@ namespace XMAT.WebServiceCapture
 
         public ScriptCollection Scripts { get; set; }
         public ScriptTypeCollection ScriptTypes { get; set; }
+        public BlockListModel BlockList { get; set; }
 
         private const int LoadedCapturesPageBreakSize = 100;
 
@@ -131,6 +132,7 @@ namespace XMAT.WebServiceCapture
             MethodFilterList = new ObservableCollection<CheckedListItem>();
             Scripts = new ScriptCollection(typeof(WebServiceCaptureScriptableEventType));
             ScriptTypes = new ScriptTypeCollection(new Type[] { typeof(WebServiceCaptureScriptParams), typeof(ClientRequest), typeof(ServerResponse), typeof(HeaderCollection) });
+            BlockList = new BlockListModel();
         }
 
         public void Initialize()
@@ -381,6 +383,24 @@ namespace XMAT.WebServiceCapture
             }
         }
 
+        private bool IsRequestBlocked(ClientRequest request)
+        {
+            if (BlockList == null || request == null)
+                return false;
+
+            // For CONNECT (SSL) requests, Host is typically empty and the Path is "host:port".
+            string host = request.Host;
+            string path = request.Path;
+            if (string.IsNullOrEmpty(host) && !string.IsNullOrEmpty(path))
+            {
+                int colon = path.IndexOf(':');
+                host = colon > 0 ? path.Substring(0, colon) : path;
+                path = null;
+            }
+
+            return BlockList.IsBlocked(host, path);
+        }
+
         private async void WebProxy_ReceivedSslConnectionRequestAsync(object sender, SslConnectionRequestEventArgs connectionEvent)
         {
             try
@@ -393,6 +413,13 @@ namespace XMAT.WebServiceCapture
             catch (Exception e)
             {
                 PublicUtilities.AppLog(LogLevel.ERROR, $"SSL connection script error {e}");
+            }
+
+            if (connectionEvent.AcceptConnection && IsRequestBlocked(connectionEvent.Request))
+            {
+                PublicUtilities.AppLog(LogLevel.INFO,
+                    $"Blocked SSL CONNECT to '{connectionEvent.Request.Host ?? connectionEvent.Request.Path}' (BlockList)");
+                connectionEvent.AcceptConnection = false;
             }
 
             string base64Body = string.Empty;
@@ -452,6 +479,13 @@ namespace XMAT.WebServiceCapture
             catch (Exception e)
             {
                 PublicUtilities.AppLog(LogLevel.ERROR, $"WebRequest script error {e}");
+            }
+
+            if (requestEvent.AcceptRequest && IsRequestBlocked(requestEvent.Request))
+            {
+                PublicUtilities.AppLog(LogLevel.INFO,
+                    $"Blocked {requestEvent.Request.Method} {requestEvent.Request.Host}{requestEvent.Request.Path} (BlockList)");
+                requestEvent.AcceptRequest = false;
             }
 
             string base64Body = string.Empty;

--- a/XMAT/Engines/WebServiceProxy/Logic/WebServiceDeviceCaptureController.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/WebServiceDeviceCaptureController.cs
@@ -388,14 +388,24 @@ namespace XMAT.WebServiceCapture
             if (BlockList == null || request == null)
                 return false;
 
-            // For CONNECT (SSL) requests, Host is typically empty and the Path is "host:port".
             string host = request.Host;
             string path = request.Path;
+
             if (string.IsNullOrEmpty(host) && !string.IsNullOrEmpty(path))
             {
-                int colon = path.IndexOf(':');
-                host = colon > 0 ? path.Substring(0, colon) : path;
-                path = null;
+                // Check if this is an absolute-form URI (e.g., GET http://example.com/path HTTP/1.1)
+                if (Uri.TryCreate(path, UriKind.Absolute, out Uri absoluteUri))
+                {
+                    host = absoluteUri.Host;
+                    path = absoluteUri.PathAndQuery;
+                }
+                // Otherwise, assume CONNECT request where Path is "host:port"
+                else
+                {
+                    int colon = path.IndexOf(':');
+                    host = colon > 0 ? path.Substring(0, colon) : path;
+                    path = null;
+                }
             }
 
             return BlockList.IsBlocked(host, path);

--- a/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
+++ b/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
@@ -99,11 +99,8 @@ namespace XMAT.WebServiceCapture.Models
             foreach (var pattern in patterns)
             {
                 Regex regex = GetRegex(pattern);
-                foreach (var candidate in candidates)
-                {
-                    if (regex.IsMatch(candidate))
-                        return true;
-                }
+                if (candidates.Where(candidate => regex.IsMatch(candidate)).Any())
+                    return true;
             }
 
             return false;

--- a/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
+++ b/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
@@ -43,8 +43,10 @@ namespace XMAT.WebServiceCapture.Models
 
         public void Remove(string pattern)
         {
-            if (pattern == null)
+            if (string.IsNullOrWhiteSpace(pattern))
                 return;
+
+            pattern = pattern.Trim();
 
             lock (_lockObj)
             {

--- a/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
+++ b/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
@@ -96,13 +96,9 @@ namespace XMAT.WebServiceCapture.Models
                     patterns[i] = BlockedUrls[i];
             }
 
-            foreach (var regex in patterns.Select(GetRegex))
-            {
-                if (candidates.Where(candidate => regex.IsMatch(candidate)).Any())
-                    return true;
-            }
-
-            return false;
+            return patterns
+                .Select(GetRegex)
+                .Any(regex => candidates.Any(candidate => regex.IsMatch(candidate)));
         }
 
         private Regex GetRegex(string pattern)

--- a/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
+++ b/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
+
+namespace XMAT.WebServiceCapture.Models
+{
+    /// <summary>
+    /// Maintains a list of URL patterns whose traffic should be blocked by the proxy.
+    /// Patterns may contain the '*' wildcard to match any sequence of characters
+    /// (e.g. "*.example.com" or "192.168.1.*"). Patterns are matched against the
+    /// request's host and optionally the full "host/path" string.
+    /// </summary>
+    public class BlockListModel
+    {
+        public ObservableCollection<string> BlockedUrls { get; } = new ObservableCollection<string>();
+
+        private readonly object _lockObj = new object();
+        private readonly Dictionary<string, Regex> _regexCache = new Dictionary<string, Regex>(StringComparer.OrdinalIgnoreCase);
+
+        public bool Add(string pattern)
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+                return false;
+
+            pattern = pattern.Trim();
+
+            lock (_lockObj)
+            {
+                foreach (var existing in BlockedUrls)
+                {
+                    if (string.Equals(existing, pattern, StringComparison.OrdinalIgnoreCase))
+                        return false;
+                }
+                BlockedUrls.Add(pattern);
+                return true;
+            }
+        }
+
+        public void Remove(string pattern)
+        {
+            if (pattern == null)
+                return;
+
+            lock (_lockObj)
+            {
+                for (int i = BlockedUrls.Count - 1; i >= 0; i--)
+                {
+                    if (string.Equals(BlockedUrls[i], pattern, StringComparison.OrdinalIgnoreCase))
+                    {
+                        BlockedUrls.RemoveAt(i);
+                    }
+                }
+                _regexCache.Remove(pattern);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_lockObj)
+            {
+                BlockedUrls.Clear();
+                _regexCache.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the given host (and optional path) matches any pattern in the block list.
+        /// </summary>
+        public bool IsBlocked(string host, string path = null)
+        {
+            if (string.IsNullOrEmpty(host))
+                return false;
+
+            string[] candidates;
+            if (!string.IsNullOrEmpty(path))
+            {
+                string normalizedPath = path.StartsWith('/') ? path : "/" + path;
+                candidates = new[] { host, host + normalizedPath };
+            }
+            else
+            {
+                candidates = new[] { host };
+            }
+
+            string[] patterns;
+            lock (_lockObj)
+            {
+                patterns = new string[BlockedUrls.Count];
+                for (int i = 0; i < BlockedUrls.Count; i++)
+                    patterns[i] = BlockedUrls[i];
+            }
+
+            foreach (var pattern in patterns)
+            {
+                Regex regex = GetRegex(pattern);
+                foreach (var candidate in candidates)
+                {
+                    if (regex.IsMatch(candidate))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private Regex GetRegex(string pattern)
+        {
+            lock (_lockObj)
+            {
+                if (_regexCache.TryGetValue(pattern, out var cached))
+                    return cached;
+
+                string escaped = Regex.Escape(pattern).Replace("\\*", ".*");
+                var regex = new Regex("^" + escaped + "$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                _regexCache[pattern] = regex;
+                return regex;
+            }
+        }
+    }
+}

--- a/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
+++ b/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace XMAT.WebServiceCapture.Models
@@ -31,11 +32,9 @@ namespace XMAT.WebServiceCapture.Models
 
             lock (_lockObj)
             {
-                foreach (var existing in BlockedUrls)
-                {
-                    if (string.Equals(existing, pattern, StringComparison.OrdinalIgnoreCase))
-                        return false;
-                }
+                if (BlockedUrls.Any(existing => string.Equals(existing, pattern, StringComparison.OrdinalIgnoreCase)))
+                    return false;
+
                 BlockedUrls.Add(pattern);
                 return true;
             }

--- a/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
+++ b/XMAT/Engines/WebServiceProxy/Models/BlockListModel.cs
@@ -96,9 +96,8 @@ namespace XMAT.WebServiceCapture.Models
                     patterns[i] = BlockedUrls[i];
             }
 
-            foreach (var pattern in patterns)
+            foreach (var regex in patterns.Select(GetRegex))
             {
-                Regex regex = GetRegex(pattern);
                 if (candidates.Where(candidate => regex.IsMatch(candidate)).Any())
                     return true;
             }

--- a/XMAT/Engines/WebServiceProxy/Views/BlockListView.xaml
+++ b/XMAT/Engines/WebServiceProxy/Views/BlockListView.xaml
@@ -1,0 +1,53 @@
+<UserControl x:Class="XMAT.WebServiceCapture.BlockListView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:XMAT.WebServiceCapture"
+             mc:Ignorable="d"
+             x:Name="BlockListViewControl"
+             d:DesignHeight="450" d:DesignWidth="600">
+    <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,8">
+            <Run Text="Enter URLs to block below. You can use * as a wildcard. Examples:"/>
+            <LineBreak/>
+            <Run Text="example.com" FontFamily="Consolas"/><Run Text=" - Blocks traffic to example.com"/>
+            <LineBreak/>
+            <Run Text="*.example.com" FontFamily="Consolas"/><Run Text=" - Blocks traffic to all subdomains of example.com"/>
+            <LineBreak/>
+            <Run Text="192.168.1.*" FontFamily="Consolas"/><Run Text=" - Blocks traffic to all IPs starting with 192.168.1"/>
+        </TextBlock>
+
+        <Grid Grid.Row="1" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBox x:Name="NewBlockTextBox" Grid.Column="0" VerticalAlignment="Center"
+                     Padding="3" KeyDown="NewBlockTextBox_KeyDown"/>
+            <Button x:Name="AddUrlBlockButton" Grid.Column="1" Margin="6,0,0,0" Padding="8,3"
+                    Content="Add URL Block" Click="AddUrlBlock_Click"/>
+        </Grid>
+
+        <TextBlock Grid.Row="2" Text="Blocked URLs:" FontWeight="Bold" Margin="0,4,0,4"/>
+
+        <ListBox x:Name="BlockedUrlList" Grid.Row="3"
+                 SelectionMode="Extended"
+                 ItemsSource="{Binding BlockList.BlockedUrls, ElementName=BlockListViewControl}"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button x:Name="RemoveSelectedButton" Content="Remove Selected" Padding="8,3" Margin="0,0,6,0"
+                    Click="RemoveSelected_Click"/>
+            <Button x:Name="ClearAllButton" Content="Clear All" Padding="8,3"
+                    Click="ClearAll_Click"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/XMAT/Engines/WebServiceProxy/Views/BlockListView.xaml.cs
+++ b/XMAT/Engines/WebServiceProxy/Views/BlockListView.xaml.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// SPDX-License-Identifier: MIT
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using XMAT.WebServiceCapture.Models;
+
+namespace XMAT.WebServiceCapture
+{
+    public partial class BlockListView : UserControl
+    {
+        public static readonly DependencyProperty BlockListProperty =
+            DependencyProperty.Register(nameof(BlockList), typeof(BlockListModel), typeof(BlockListView),
+                new PropertyMetadata(null));
+
+        public BlockListModel BlockList
+        {
+            get => (BlockListModel)GetValue(BlockListProperty);
+            set => SetValue(BlockListProperty, value);
+        }
+
+        public BlockListView()
+        {
+            InitializeComponent();
+        }
+
+        private void AddUrlBlock_Click(object sender, RoutedEventArgs e)
+        {
+            AddPattern();
+        }
+
+        private void NewBlockTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                AddPattern();
+                e.Handled = true;
+            }
+        }
+
+        private void AddPattern()
+        {
+            if (BlockList == null)
+                return;
+
+            string text = NewBlockTextBox.Text;
+            if (BlockList.Add(text))
+            {
+                NewBlockTextBox.Clear();
+            }
+        }
+
+        private void RemoveSelected_Click(object sender, RoutedEventArgs e)
+        {
+            if (BlockList == null)
+                return;
+
+            var selectedItems = new System.Collections.Generic.List<object>();
+            foreach (var item in BlockedUrlList.SelectedItems)
+            {
+                selectedItems.Add(item);
+            }
+            foreach (var item in selectedItems)
+            {
+                if (item is string s)
+                {
+                    BlockList.Remove(s);
+                }
+            }
+        }
+
+        private void ClearAll_Click(object sender, RoutedEventArgs e)
+        {
+            BlockList?.Clear();
+        }
+    }
+}

--- a/XMAT/Engines/WebServiceProxy/Views/BlockListView.xaml.cs
+++ b/XMAT/Engines/WebServiceProxy/Views/BlockListView.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 // SPDX-License-Identifier: MIT
 
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -62,12 +63,9 @@ namespace XMAT.WebServiceCapture
             {
                 selectedItems.Add(item);
             }
-            foreach (var item in selectedItems)
+            foreach (var s in selectedItems.OfType<string>())
             {
-                if (item is string s)
-                {
-                    BlockList.Remove(s);
-                }
+                BlockList.Remove(s);
             }
         }
 

--- a/XMAT/Engines/WebServiceProxy/Views/CaptureConnectionView.xaml
+++ b/XMAT/Engines/WebServiceProxy/Views/CaptureConnectionView.xaml
@@ -219,6 +219,9 @@
             <TabItem x:Name="ScriptEditorTab" Header="Script Editor">
                 <app:ScriptEditorView ScriptCollection="{Binding CaptureController.Scripts}" ScriptTypeCollection="{Binding CaptureController.ScriptTypes}" TabSize="4"/>
             </TabItem>
+            <TabItem x:Name="BlockListTab" Header="Block List">
+                <local:BlockListView BlockList="{Binding CaptureController.BlockList}"/>
+            </TabItem>
         </TabControl>
     </Grid>
 </UserControl>

--- a/XMAT/XboxMultiplayerAnalysisTool.csproj
+++ b/XMAT/XboxMultiplayerAnalysisTool.csproj
@@ -74,6 +74,9 @@
     <Page Update="Engines\WebServiceProxy\Views\CaptureConnectionView.xaml">
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>
+    <Page Update="Engines\WebServiceProxy\Views\BlockListView.xaml">
+      <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
+    </Page>
     <Page Update="Engines\WebServiceProxy\Views\CaptureControlView.xaml">
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>


### PR DESCRIPTION
Adds a Block List tab to the WebProxy capture view so users can easily block traffic to and from URLs without writing scripts. Required for XR74-07 and XR74-08 testing.

- BlockListModel supports wildcard patterns (e.g. example.com, *.example.com, 192.168.1.*, example.com/path/*) matched against request host and host+path, case-insensitive.

- WebServiceDeviceCaptureController checks the block list in both SSL CONNECT and HTTP request handlers, rejecting matching requests after script evaluation and logging the block.

- New BlockListView WPF user control with add/remove/clear UI, wired into CaptureConnectionView as a 'Block List' tab next to 'Script Editor'.

- 11 new unit tests in BlockListModelTests covering add/remove/clear, case-insensitivity, wildcard matching for subdomains/IP prefixes/paths, and regex-escaping of pattern metacharacters.