### PR TITLE
Bug Fix: Recreate an Expiring Root Cert when Needed

### DIFF
--- a/XMAT.Tests/CertificateManagerTests.cs
+++ b/XMAT.Tests/CertificateManagerTests.cs
@@ -11,6 +11,8 @@ namespace XMAT.Tests
 {
     public class CertificateManagerTests
     {
+        private static readonly TimeSpan CertificateExpirationTolerance = TimeSpan.FromMinutes(1);
+
         [Fact]
         public void CreateRootCertificate_ReturnsTrue_WhenCachedRootCertCanIssueHostCertificates()
         {
@@ -36,7 +38,7 @@ namespace XMAT.Tests
             DateTime hostNotAfterUtc = hostCert.NotAfter.ToUniversalTime();
 
             Assert.True(hostNotAfterUtc <= rootNotAfterUtc);
-            Assert.True(rootNotAfterUtc - hostNotAfterUtc < TimeSpan.FromMinutes(1));
+            Assert.True(rootNotAfterUtc - hostNotAfterUtc < CertificateExpirationTolerance);
         }
 
         private static X509Certificate2 CreateTestRootCertificate(DateTimeOffset notAfter)

--- a/XMAT.Tests/CertificateManagerTests.cs
+++ b/XMAT.Tests/CertificateManagerTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// SPDX-License-Identifier: MIT
+
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using XMAT.WebServiceCapture.Proxy;
+
+namespace XMAT.Tests
+{
+    public class CertificateManagerTests
+    {
+        [Fact]
+        public void CreateRootCertificate_ReturnsTrue_WhenCachedRootCertCanIssueHostCertificates()
+        {
+            using var manager = new CertificateManager(storeCerts: false);
+            using var rootCert = CreateTestRootCertificate(DateTimeOffset.UtcNow.AddYears(4));
+
+            SetRootCertificate(manager, rootCert);
+
+            Assert.True(manager.CreateRootCertificate());
+        }
+
+        [Fact]
+        public void CreateHostCertificate_ClampsNotAfterToIssuerExpiration()
+        {
+            using var manager = new CertificateManager(storeCerts: false);
+            using var rootCert = CreateTestRootCertificate(DateTimeOffset.UtcNow.AddMonths(6));
+
+            SetRootCertificate(manager, rootCert);
+
+            using var hostCert = manager.CreateHostCertificate("example.test");
+
+            DateTime rootNotAfterUtc = rootCert.NotAfter.ToUniversalTime();
+            DateTime hostNotAfterUtc = hostCert.NotAfter.ToUniversalTime();
+
+            Assert.True(hostNotAfterUtc <= rootNotAfterUtc);
+            Assert.True(rootNotAfterUtc - hostNotAfterUtc < TimeSpan.FromMinutes(1));
+        }
+
+        private static X509Certificate2 CreateTestRootCertificate(DateTimeOffset notAfter)
+        {
+            using RSA rsa = RSA.Create(4096);
+
+            CertificateRequest req = new CertificateRequest(
+                "CN=Test Root Certificate, O=Microsoft",
+                rsa,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+
+            req.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+            req.CertificateExtensions.Add(new X509KeyUsageExtension(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign, true));
+            req.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(req.PublicKey, false));
+
+            using X509Certificate2 cert = req.CreateSelfSigned(
+                DateTimeOffset.UtcNow.AddYears(-1),
+                notAfter);
+
+            return X509CertificateLoader.LoadPkcs12(
+                cert.Export(X509ContentType.Pfx, string.Empty),
+                string.Empty,
+                X509KeyStorageFlags.Exportable | X509KeyStorageFlags.PersistKeySet);
+        }
+
+        private static void SetRootCertificate(CertificateManager manager, X509Certificate2 rootCert)
+        {
+            typeof(CertificateManager)
+                .GetField("_rootCert", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(manager, rootCert);
+        }
+    }
+}

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/CertificateManager.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/CertificateManager.cs
@@ -108,11 +108,18 @@ namespace XMAT.WebServiceCapture.Proxy
                     $"CN={AuthorityName}, O={IssuerName}", false);
                 if (certs.Count > 0)
                 {
+                    X509Certificate2 mostValidCert = certs[0];
+                    for (int i = 1; i < certs.Count; i++)
+                    {
+                        if (certs[i].NotAfter > mostValidCert.NotAfter)
+                            mostValidCert = certs[i];
+                    }
+
                     // If the existing root cert doesn't have enough validity remaining
                     // to issue host certs, remove it and create a new one.
-                    if (certs[0].NotAfter > DateTimeOffset.UtcNow.AddYears(HostCertValidityYears))
+                    if (mostValidCert.NotAfter > DateTimeOffset.UtcNow.AddYears(HostCertValidityYears))
                     {
-                        _rootCert = certs[0];
+                        _rootCert = mostValidCert;
                         return true;
                     }
 

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/CertificateManager.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/CertificateManager.cs
@@ -187,6 +187,10 @@ namespace XMAT.WebServiceCapture.Proxy
             // the root cert expires before host certs.
             DateTimeOffset notAfter = DateTimeOffset.UtcNow.AddYears(HostCertValidityYears);
             DateTimeOffset issuerNotAfter = _rootCert.NotAfter;
+
+            if (issuerNotAfter <= DateTimeOffset.UtcNow)
+                throw new InvalidOperationException("Root certificate has expired and cannot be used to issue host certificates.");
+
             if (notAfter > issuerNotAfter)
             {
                 notAfter = issuerNotAfter;

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/CertificateManager.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/CertificateManager.cs
@@ -22,6 +22,9 @@ namespace XMAT.WebServiceCapture.Proxy
         private readonly string CertFileNameFiddlerPem = "FiddlerRoot.pem";
         private readonly string CertPassword = string.Empty;
 
+        private const int RootCertValidityYears = 4;
+        private const int HostCertValidityYears = 3;
+
         private readonly X509Store _rootStore;
         private readonly X509Store _myStore;
 
@@ -97,7 +100,7 @@ namespace XMAT.WebServiceCapture.Proxy
         {
             lock (_rootLock)
             {
-                if (_rootCert != null)
+                if (_rootCert != null && _rootCert.NotAfter > DateTimeOffset.UtcNow.AddYears(HostCertValidityYears))
                     return true;
 
                 var certs = _rootStore.Certificates.Find(
@@ -105,8 +108,15 @@ namespace XMAT.WebServiceCapture.Proxy
                     $"CN={AuthorityName}, O={IssuerName}", false);
                 if (certs.Count > 0)
                 {
-                    _rootCert = certs[0];
-                    return true;
+                    // If the existing root cert doesn't have enough validity remaining
+                    // to issue host certs, remove it and create a new one.
+                    if (certs[0].NotAfter > DateTimeOffset.UtcNow.AddYears(HostCertValidityYears))
+                    {
+                        _rootCert = certs[0];
+                        return true;
+                    }
+
+                    _rootStore.RemoveRange(certs);
                 }
 
                 try
@@ -133,7 +143,7 @@ namespace XMAT.WebServiceCapture.Proxy
 
                     var cert = req.CreateSelfSigned(
                         DateTimeOffset.UtcNow.AddYears(-1),
-                        DateTimeOffset.UtcNow.AddYears(4));
+                        DateTimeOffset.UtcNow.AddYears(RootCertValidityYears));
                     cert.FriendlyName = AuthorityName;
 
                     _rootCert = X509CertificateLoader.LoadPkcs12(
@@ -173,10 +183,19 @@ namespace XMAT.WebServiceCapture.Proxy
 
             byte[] serial = RandomNumberGenerator.GetBytes(20);
 
+            // Safety net: clamp notAfter to never exceed the issuer cert's NotAfter in case
+            // the root cert expires before host certs.
+            DateTimeOffset notAfter = DateTimeOffset.UtcNow.AddYears(HostCertValidityYears);
+            DateTimeOffset issuerNotAfter = _rootCert.NotAfter;
+            if (notAfter > issuerNotAfter)
+            {
+                notAfter = issuerNotAfter;
+            }
+
             X509Certificate2 cert = req.Create(
                 _rootCert,
                 DateTimeOffset.UtcNow.AddYears(-1),
-                DateTimeOffset.UtcNow.AddYears(3),
+                notAfter,
                 serial);
 
             X509Certificate2 certWithKey = cert.CopyWithPrivateKey(rsa);

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/CertificateManager.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/CertificateManager.cs
@@ -100,7 +100,7 @@ namespace XMAT.WebServiceCapture.Proxy
         {
             lock (_rootLock)
             {
-                if (_rootCert != null && _rootCert.NotAfter > DateTimeOffset.UtcNow.AddYears(HostCertValidityYears))
+if (_rootCert != null && _rootCert.NotAfter >= DateTimeOffset.UtcNow.AddYears(HostCertValidityYears))
                     return true;
 
                 var certs = _rootStore.Certificates.Find(


### PR DESCRIPTION
Bug Fix for expiring certificate recreation: 
In CertificateManager, added a check to make sure the root cert will re-create if the host cert would have a later expiration date (preventing the error). Added a safety net in CreateHostCertificate() to make sure that even if the root cert has an earlier exp date, the generated host cert will have an earlier one.

Error from old Root Certificate:
Exception in connection handler: System.ArgumentException: The requested notAfter value (XXXXXXX) is later than issuerCertificate.NotAfter (XXXXXXX). (Parameter 'notAfter')