### PR TITLE
Add Bypass List for TLS Passthrough on Specified Hosts

### DIFF
--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.IO.Pipelines;
 using System.Net.Http;
 using System.Net.Security;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
@@ -117,9 +118,19 @@ namespace XMAT.WebServiceCapture.Proxy
             await clientStream.WriteAsync(responseBytes, ct).ConfigureAwait(false);
             await clientStream.FlushAsync(ct).ConfigureAwait(false);
 
+            var hostname = GetHostFromPath(connectRequest.Path);
+            int port = GetPortFromPath(connectRequest.Path);
+
+            // If the host is on the bypass list, tunnel raw bytes without TLS interception
+            if (_proxy.BypassList != null && _proxy.BypassList.IsBypassed(hostname))
+            {
+                _logger.Log(connectionID, LogLevel.INFO, $"Bypassing TLS interception for {hostname}:{port}");
+                await TunnelConnectionAsync(connectionID, clientStream, hostname, port, ct).ConfigureAwait(false);
+                return;
+            }
+
             // Perform TLS handshake with dynamic certificate
             var sslStream = new SslStream(clientStream, leaveInnerStreamOpen: true);
-            var hostname = GetHostFromPath(connectRequest.Path);
             var certificate = _certManager.GetCertificateForHost(hostname);
 
             try
@@ -449,6 +460,56 @@ namespace XMAT.WebServiceCapture.Proxy
             if (path.Contains(':'))
                 return path.Split(':')[0];
             return path;
+        }
+
+        private static int GetPortFromPath(string path)
+        {
+            if (path.Contains(':'))
+            {
+                string portStr = path.Split(':')[1];
+                if (int.TryParse(portStr, out int port))
+                    return port;
+            }
+            return 443;
+        }
+
+        private async Task TunnelConnectionAsync(int connectionID, Stream clientStream, string hostname, int port, CancellationToken ct)
+        {
+            using var tcpClient = new TcpClient();
+            try
+            {
+                await tcpClient.ConnectAsync(hostname, port, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(connectionID, LogLevel.ERROR, $"Failed to connect to {hostname}:{port} for bypass tunnel: {ex.Message}");
+                return;
+            }
+
+            using var serverStream = tcpClient.GetStream();
+
+            var clientToServer = RelayAsync(clientStream, serverStream, ct);
+            var serverToClient = RelayAsync(serverStream, clientStream, ct);
+
+            await Task.WhenAny(clientToServer, serverToClient).ConfigureAwait(false);
+        }
+
+        private static async Task RelayAsync(Stream from, Stream to, CancellationToken ct)
+        {
+            byte[] buffer = new byte[8192];
+            try
+            {
+                int bytesRead;
+                while ((bytesRead = await from.ReadAsync(buffer, ct).ConfigureAwait(false)) > 0)
+                {
+                    await to.WriteAsync(buffer.AsMemory(0, bytesRead), ct).ConfigureAwait(false);
+                    await to.FlushAsync(ct).ConfigureAwait(false);
+                }
+            }
+            catch (Exception)
+            {
+                // Connection closed or cancelled — expected during tunnel teardown
+            }
         }
 
         private static bool IsContentHeader(string headerKey)

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
@@ -118,13 +118,14 @@ namespace XMAT.WebServiceCapture.Proxy
             await clientStream.WriteAsync(responseBytes, ct).ConfigureAwait(false);
             await clientStream.FlushAsync(ct).ConfigureAwait(false);
 
-            var hostname = GetHostFromPath(connectRequest.Path);
-            int port = GetPortFromPath(connectRequest.Path);
+            string hostname = connectRequest.Host ?? GetHostFromPath(connectRequest.Path);
+            int port = connectRequest.Port > 0 ? connectRequest.Port : GetPortFromPath(connectRequest.Path);
 
             // If the host is on the bypass list, tunnel raw bytes without TLS interception
             if (_proxy.BypassList != null && _proxy.BypassList.IsBypassed(hostname))
             {
                 _logger.Log(connectionID, LogLevel.INFO, $"Bypassing TLS interception for {hostname}:{port}");
+                _proxy.RaiseCompletedSslConnectionRequest(connectionID, connectRequest);
                 await TunnelConnectionAsync(connectionID, clientStream, hostname, port, ct).ConfigureAwait(false);
                 return;
             }

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
@@ -500,7 +500,21 @@ namespace XMAT.WebServiceCapture.Proxy
             {
                 await tcpClient.ConnectAsync(hostname, port, ct).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (SocketException ex)
+            {
+                _logger.Log(connectionID, LogLevel.ERROR, $"Failed to connect to {hostname}:{port} for bypass tunnel: {ex.Message}");
+                return;
+            }
+            catch (IOException ex)
+            {
+                _logger.Log(connectionID, LogLevel.ERROR, $"Failed to connect to {hostname}:{port} for bypass tunnel: {ex.Message}");
+                return;
+            }
+            catch (AuthenticationException ex)
             {
                 _logger.Log(connectionID, LogLevel.ERROR, $"Failed to connect to {hostname}:{port} for bypass tunnel: {ex.Message}");
                 return;

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
@@ -458,16 +458,35 @@ namespace XMAT.WebServiceCapture.Proxy
 
         private static string GetHostFromPath(string path)
         {
-            if (path.Contains(':'))
-                return path.Split(':')[0];
+            if (path.StartsWith('['))
+            {
+                int closingBracket = path.IndexOf(']');
+                if (closingBracket >= 0)
+                    return path[..(closingBracket + 1)];
+            }
+            int colon = path.IndexOf(':');
+            if (colon >= 0)
+                return path[..colon];
             return path;
         }
 
         private static int GetPortFromPath(string path)
         {
-            if (path.Contains(':'))
+            if (path.StartsWith('['))
             {
-                string portStr = path.Split(':')[1];
+                int colonAfterBracket = path.IndexOf("]:");
+                if (colonAfterBracket >= 0)
+                {
+                    string portStr = path[(colonAfterBracket + 2)..];
+                    if (int.TryParse(portStr, out int port))
+                        return port;
+                }
+                return 443;
+            }
+            int colon = path.IndexOf(':');
+            if (colon >= 0)
+            {
+                string portStr = path[(colon + 1)..];
                 if (int.TryParse(portStr, out int port))
                     return port;
             }

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/ForwardProxyConnectionHandler.cs
@@ -540,7 +540,15 @@ namespace XMAT.WebServiceCapture.Proxy
                     await to.FlushAsync(ct).ConfigureAwait(false);
                 }
             }
-            catch (Exception)
+            catch (OperationCanceledException)
+            {
+                // Connection closed or cancelled — expected during tunnel teardown
+            }
+            catch (IOException)
+            {
+                // Connection closed or cancelled — expected during tunnel teardown
+            }
+            catch (ObjectDisposedException)
             {
                 // Connection closed or cancelled — expected during tunnel teardown
             }

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/IWebServiceProxy.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/IWebServiceProxy.cs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 using System;
+using XMAT.WebServiceCapture.Models;
 
 namespace XMAT.WebServiceCapture.Proxy
 {
@@ -18,6 +19,8 @@ namespace XMAT.WebServiceCapture.Proxy
         event EventHandler ProxyStopped;
 
         bool IsProxyEnabled { get; }
+
+        BypassListModel BypassList { get; set; }
 
         void StartProxy(WebServiceProxyOptions options);
 

--- a/XMAT/Engines/WebServiceProxy/Logic/Proxy/WebServiceProxy.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/Proxy/WebServiceProxy.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using XMAT.WebServiceCapture.Models;
 
 namespace XMAT.WebServiceCapture.Proxy
 {
@@ -43,6 +44,14 @@ namespace XMAT.WebServiceCapture.Proxy
 
         private int _availableConnectionId;
         private int _availableRequestId;
+
+        internal BypassListModel BypassList { get; set; }
+
+        BypassListModel IWebServiceProxy.BypassList
+        {
+            get => BypassList;
+            set => BypassList = value;
+        }
 
         internal static bool Initialize(string certPath)
         {

--- a/XMAT/Engines/WebServiceProxy/Logic/WebServiceDeviceCaptureController.cs
+++ b/XMAT/Engines/WebServiceProxy/Logic/WebServiceDeviceCaptureController.cs
@@ -82,6 +82,7 @@ namespace XMAT.WebServiceCapture
         public ScriptCollection Scripts { get; set; }
         public ScriptTypeCollection ScriptTypes { get; set; }
         public BlockListModel BlockList { get; set; }
+        public BypassListModel BypassList { get; set; }
 
         private const int LoadedCapturesPageBreakSize = 100;
 
@@ -133,6 +134,7 @@ namespace XMAT.WebServiceCapture
             Scripts = new ScriptCollection(typeof(WebServiceCaptureScriptableEventType));
             ScriptTypes = new ScriptTypeCollection(new Type[] { typeof(WebServiceCaptureScriptParams), typeof(ClientRequest), typeof(ServerResponse), typeof(HeaderCollection) });
             BlockList = new BlockListModel();
+            BypassList = new BypassListModel();
         }
 
         public void Initialize()
@@ -154,6 +156,7 @@ namespace XMAT.WebServiceCapture
                 PromptToDisableOnClose = (CaptureMethod.PreferencesModel as PreferencesModel).PromptToDisableOnClose;
 
                 _webProxy = WebServiceProxy.CreateProxy();
+                _webProxy.BypassList = BypassList;
                 _webProxy.ReceivedSslConnectionRequest += WebProxy_ReceivedSslConnectionRequestAsync;
                 _webProxy.CompletedSslConnectionRequest += WebProxy_CompletedSslConnectionRequest;
                 _webProxy.ReceivedWebRequest += WebProxy_ReceivedWebRequestAsync;

--- a/XMAT/Engines/WebServiceProxy/Models/BypassListModel.cs
+++ b/XMAT/Engines/WebServiceProxy/Models/BypassListModel.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// SPDX-License-Identifier: MIT
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace XMAT.WebServiceCapture.Models
+{
+    /// <summary>
+    /// Maintains a list of host patterns whose traffic should be tunneled through
+    /// the proxy without TLS interception. Patterns may contain the '*' wildcard
+    /// to match any sequence of characters (e.g. "*.auth.xboxlive.com").
+    /// Matching hosts will have their CONNECT tunnels relayed as opaque byte streams.
+    /// </summary>
+    public class BypassListModel
+    {
+        public ObservableCollection<string> BypassedUrls { get; } = new ObservableCollection<string>();
+
+        private readonly object _lockObj = new object();
+        private readonly Dictionary<string, Regex> _regexCache = new Dictionary<string, Regex>(StringComparer.OrdinalIgnoreCase);
+
+        public bool Add(string pattern)
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+                return false;
+
+            pattern = pattern.Trim();
+
+            lock (_lockObj)
+            {
+                if (BypassedUrls.Any(existing => string.Equals(existing, pattern, StringComparison.OrdinalIgnoreCase)))
+                    return false;
+
+                BypassedUrls.Add(pattern);
+                return true;
+            }
+        }
+
+        public void Remove(string pattern)
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+                return;
+
+            pattern = pattern.Trim();
+
+            lock (_lockObj)
+            {
+                for (int i = BypassedUrls.Count - 1; i >= 0; i--)
+                {
+                    if (string.Equals(BypassedUrls[i], pattern, StringComparison.OrdinalIgnoreCase))
+                    {
+                        BypassedUrls.RemoveAt(i);
+                    }
+                }
+                _regexCache.Remove(pattern);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_lockObj)
+            {
+                BypassedUrls.Clear();
+                _regexCache.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the given host matches any pattern in the bypass list.
+        /// </summary>
+        public bool IsBypassed(string host)
+        {
+            if (string.IsNullOrEmpty(host))
+                return false;
+
+            string[] patterns;
+            lock (_lockObj)
+            {
+                patterns = new string[BypassedUrls.Count];
+                for (int i = 0; i < BypassedUrls.Count; i++)
+                    patterns[i] = BypassedUrls[i];
+            }
+
+            return patterns
+                .Select(GetRegex)
+                .Any(regex => regex.IsMatch(host));
+        }
+
+        private Regex GetRegex(string pattern)
+        {
+            lock (_lockObj)
+            {
+                if (_regexCache.TryGetValue(pattern, out var cached))
+                    return cached;
+
+                string escaped = Regex.Escape(pattern).Replace("\\*", ".*");
+                var regex = new Regex("^" + escaped + "$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                _regexCache[pattern] = regex;
+                return regex;
+            }
+        }
+    }
+}

--- a/XMAT/Engines/WebServiceProxy/Views/BypassListView.xaml
+++ b/XMAT/Engines/WebServiceProxy/Views/BypassListView.xaml
@@ -1,0 +1,53 @@
+<UserControl x:Class="XMAT.WebServiceCapture.BypassListView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:XMAT.WebServiceCapture"
+             mc:Ignorable="d"
+             x:Name="BypassListViewControl"
+             d:DesignHeight="450" d:DesignWidth="600">
+    <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" TextWrapping="Wrap" Margin="0,0,0,8">
+            <Run Text="Enter hostnames to bypass TLS decryption. Traffic to these hosts will be tunneled without interception. Use * as a wildcard. Examples:"/>
+            <LineBreak/>
+            <Run Text="xsts.auth.xboxlive.com" FontFamily="Consolas"/><Run Text=" - Bypasses decryption for XSTS auth"/>
+            <LineBreak/>
+            <Run Text="*.auth.xboxlive.com" FontFamily="Consolas"/><Run Text=" - Bypasses all Xbox Live auth subdomains"/>
+            <LineBreak/>
+            <Run Text="login.live.com" FontFamily="Consolas"/><Run Text=" - Bypasses Microsoft login"/>
+        </TextBlock>
+
+        <Grid Grid.Row="1" Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <TextBox x:Name="NewBypassTextBox" Grid.Column="0" VerticalAlignment="Center"
+                     Padding="3" KeyDown="NewBypassTextBox_KeyDown"/>
+            <Button x:Name="AddBypassButton" Grid.Column="1" Margin="6,0,0,0" Padding="8,3"
+                    Content="Add Bypass" Click="AddBypass_Click"/>
+        </Grid>
+
+        <TextBlock Grid.Row="2" Text="Bypassed Hosts:" FontWeight="Bold" Margin="0,4,0,4"/>
+
+        <ListBox x:Name="BypassedUrlList" Grid.Row="3"
+                 SelectionMode="Extended"
+                 ItemsSource="{Binding BypassList.BypassedUrls, ElementName=BypassListViewControl}"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button x:Name="RemoveSelectedButton" Content="Remove Selected" Padding="8,3" Margin="0,0,6,0"
+                    Click="RemoveSelected_Click"/>
+            <Button x:Name="ClearAllButton" Content="Clear All" Padding="8,3"
+                    Click="ClearAll_Click"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/XMAT/Engines/WebServiceProxy/Views/BypassListView.xaml.cs
+++ b/XMAT/Engines/WebServiceProxy/Views/BypassListView.xaml.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// SPDX-License-Identifier: MIT
+
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using XMAT.WebServiceCapture.Models;
+
+namespace XMAT.WebServiceCapture
+{
+    public partial class BypassListView : UserControl
+    {
+        public static readonly DependencyProperty BypassListProperty =
+            DependencyProperty.Register(nameof(BypassList), typeof(BypassListModel), typeof(BypassListView),
+                new PropertyMetadata(null));
+
+        public BypassListModel BypassList
+        {
+            get => (BypassListModel)GetValue(BypassListProperty);
+            set => SetValue(BypassListProperty, value);
+        }
+
+        public BypassListView()
+        {
+            InitializeComponent();
+        }
+
+        private void AddBypass_Click(object sender, RoutedEventArgs e)
+        {
+            AddPattern();
+        }
+
+        private void NewBypassTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                AddPattern();
+                e.Handled = true;
+            }
+        }
+
+        private void AddPattern()
+        {
+            if (BypassList == null)
+                return;
+
+            string text = NewBypassTextBox.Text;
+            if (BypassList.Add(text))
+            {
+                NewBypassTextBox.Clear();
+            }
+        }
+
+        private void RemoveSelected_Click(object sender, RoutedEventArgs e)
+        {
+            if (BypassList == null)
+                return;
+
+            var selectedItems = new System.Collections.Generic.List<object>();
+            foreach (var item in BypassedUrlList.SelectedItems)
+            {
+                selectedItems.Add(item);
+            }
+            foreach (var s in selectedItems.OfType<string>())
+            {
+                BypassList.Remove(s);
+            }
+        }
+
+        private void ClearAll_Click(object sender, RoutedEventArgs e)
+        {
+            BypassList?.Clear();
+        }
+    }
+}

--- a/XMAT/Engines/WebServiceProxy/Views/CaptureConnectionView.xaml
+++ b/XMAT/Engines/WebServiceProxy/Views/CaptureConnectionView.xaml
@@ -222,6 +222,9 @@
             <TabItem x:Name="BlockListTab" Header="Block List">
                 <local:BlockListView BlockList="{Binding CaptureController.BlockList}"/>
             </TabItem>
+            <TabItem x:Name="BypassListTab" Header="Bypass List">
+                <local:BypassListView BypassList="{Binding CaptureController.BypassList}"/>
+            </TabItem>
         </TabControl>
     </Grid>
 </UserControl>


### PR DESCRIPTION
Adds a Bypass List feature (similar to Block List implementation) that allows users to specify hostnames that should be tunneled through the proxy without TLS interception. Traffic to bypassed hosts is relayed as raw bytes, preserving channel-bound signatures and certificate pinning.

This fixes issues where Xbox Live auth (XSTS) and Store endpoints fail when proxied because their request signatures are bound to the TLS session.